### PR TITLE
Enhance TextBoard multiplayer support

### DIFF
--- a/TextBoard/CfgFunctions.hpp
+++ b/TextBoard/CfgFunctions.hpp
@@ -1,0 +1,16 @@
+class CfgFunctions
+{
+    class TextBoard
+    {
+        class Functions
+        {
+            file = "TextBoard\functions";
+            class createBoard{};
+            class inputClosed{};
+            class openInput{};
+            class setText{};
+            class addConsoleAction{};
+            class addDrawHandler{};
+        };
+    };
+};

--- a/TextBoard/XEH_preInit.sqf
+++ b/TextBoard/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+tb_fnc_createBoard = compile preprocessFileLineNumbers "TextBoard\functions\fn_createBoard.sqf";
+tb_fnc_inputClosed = compile preprocessFileLineNumbers "TextBoard\functions\fn_inputClosed.sqf";
+tb_fnc_openInput = compile preprocessFileLineNumbers "TextBoard\functions\fn_openInput.sqf";
+tb_fnc_setText = compile preprocessFileLineNumbers "TextBoard\functions\fn_setText.sqf";
+tb_fnc_addConsoleAction = compile preprocessFileLineNumbers "TextBoard\functions\fn_addConsoleAction.sqf";
+tb_fnc_addDrawHandler = compile preprocessFileLineNumbers "TextBoard\functions\fn_addDrawHandler.sqf";
+tb_eh_counter = 0;

--- a/TextBoard/config.cpp
+++ b/TextBoard/config.cpp
@@ -1,0 +1,12 @@
+class CfgPatches
+{
+    class TextBoard
+    {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = 0.1;
+        requiredAddons[] = {"cba_main"};
+    };
+};
+#include "CfgFunctions.hpp"
+#include "ui\dialog.hpp"

--- a/TextBoard/functions/fn_addConsoleAction.sqf
+++ b/TextBoard/functions/fn_addConsoleAction.sqf
@@ -1,0 +1,4 @@
+params["_console","_board"];
+if(isNull _console || isNull _board)exitWith{};
+if(!hasInterface)exitWith{[_console,_board] remoteExecCall["tb_fnc_addConsoleAction",0,true]};
+[_console,0,["ACE_MainActions"],{"Edit"},{[_board] call tb_fnc_openInput},{true}] call ace_interact_menu_fnc_addActionToObject;

--- a/TextBoard/functions/fn_addDrawHandler.sqf
+++ b/TextBoard/functions/fn_addDrawHandler.sqf
@@ -1,0 +1,5 @@
+params["_board"];
+if(isNull _board)exitWith{};
+private _id=addMissionEventHandler["Draw3D",{params["_id"];private _b=missionNamespace getVariable["tb_board_"+str _id,objNull];if(isNull _b)exitWith{removeMissionEventHandler["Draw3D",_id]};drawIcon3D["",[1,1,1,1],_b modelToWorld[0,0,1],0,0,0,_b getVariable["tb_text",""],2,0.05,"RobotoCondensed"];}];
+_board setVariable["tb_eh",_id];
+missionNamespace setVariable["tb_board_"+str _id,_board];

--- a/TextBoard/functions/fn_createBoard.sqf
+++ b/TextBoard/functions/fn_createBoard.sqf
@@ -1,0 +1,10 @@
+params["_target"];
+if(isNull _target)exitWith{objNull};
+if(!isServer)exitWith{[_target] remoteExecCall["tb_fnc_createBoard",2]};
+private _dir=getDir _target;
+private _board="Land_InfoStand_V1_F" createVehicle [0,0,0];
+_board setDir _dir;
+_board setPosATL (_target modelToWorld [0,1,1]);
+_board setVariable["tb_text","",true];
+[_board] remoteExec["tb_fnc_addDrawHandler",0,true];
+_board

--- a/TextBoard/functions/fn_inputClosed.sqf
+++ b/TextBoard/functions/fn_inputClosed.sqf
@@ -1,0 +1,7 @@
+params["_type","_params"];
+private _display=ctrlParent (_params#0);
+private _text=ctrlText (_display displayCtrl 1);
+private _board=missionNamespace getVariable["tb_currentBoard",objNull];
+[_board,_text] remoteExecCall["tb_fnc_setText",2];
+missionNamespace setVariable["tb_currentBoard",nil];
+closeDialog 1;

--- a/TextBoard/functions/fn_openInput.sqf
+++ b/TextBoard/functions/fn_openInput.sqf
@@ -1,0 +1,4 @@
+params["_board"];
+if(isNull _board)exitWith{};
+missionNamespace setVariable["tb_currentBoard",_board];
+createDialog "TB_InputDialog";

--- a/TextBoard/functions/fn_setText.sqf
+++ b/TextBoard/functions/fn_setText.sqf
@@ -1,0 +1,3 @@
+params["_board","_text"];
+if(isNull _board)exitWith{};
+_board setVariable["tb_text",_text,true];

--- a/TextBoard/ui/dialog.hpp
+++ b/TextBoard/ui/dialog.hpp
@@ -1,0 +1,82 @@
+class TB_RscText
+{
+    type = 0;
+    idc = -1;
+    style = 0;
+    colorBackground[] = {0,0,0,0};
+    colorText[] = {1,1,1,1};
+    font = "PuristaMedium";
+    sizeEx = 0.04;
+    shadow = 2;
+};
+class TB_RscButton
+{
+    type = 1;
+    style = 2;
+    idc = -1;
+    colorText[] = {1,1,1,1};
+    colorDisabled[] = {0.4,0.4,0.4,1};
+    colorBackground[] = {0.2,0.2,0.2,0.9};
+    colorBackgroundDisabled[] = {0.95,0.95,0.95,1};
+    colorBackgroundActive[] = {0.3,0.3,0.3,1};
+    colorFocused[] = {0.3,0.3,0.3,1};
+    colorShadow[] = {0,0,0,1};
+    colorBorder[] = {0,0,0,1};
+    soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter",0.09,1};
+    soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush",0.09,1};
+    soundClick[] = {"\A3\ui_f\data\sound\RscButton\soundClick",0.09,1};
+    soundEscape[] = {"\A3\ui_f\data\sound\RscButton\soundEscape",0.09,1};
+    font = "PuristaMedium";
+    sizeEx = 0.04;
+    offsetX = 0.003;
+    offsetY = 0.003;
+    offsetPressedX = 0.002;
+    offsetPressedY = 0.002;
+    borderSize = 0;
+};
+class TB_RscEdit
+{
+    type = 2;
+    idc = -1;
+    style = 0;
+    font = "PuristaMedium";
+    sizeEx = 0.04;
+    colorBackground[] = {0,0,0,0.8};
+    colorText[] = {1,1,1,1};
+    shadow = 2;
+};
+class TB_InputDialog
+{
+    idd = -1;
+    movingEnable = 0;
+    enableSimulation = 1;
+    class Controls
+    {
+        class Background: TB_RscText
+        {
+            x = 0.4 * safezoneW + safezoneX;
+            y = 0.4 * safezoneH + safezoneY;
+            w = 0.2 * safezoneW;
+            h = 0.15 * safezoneH;
+            colorBackground[] = {0,0,0,0.8};
+        };
+        class Input: TB_RscEdit
+        {
+            idc = 1;
+            x = 0.41 * safezoneW + safezoneX;
+            y = 0.45 * safezoneH + safezoneY;
+            w = 0.18 * safezoneW;
+            h = 0.04 * safezoneH;
+        };
+        class Ok: TB_RscButton
+        {
+            idc = 2;
+            text = "OK";
+            x = 0.46 * safezoneW + safezoneX;
+            y = 0.52 * safezoneH + safezoneY;
+            w = 0.08 * safezoneW;
+            h = 0.04 * safezoneH;
+            action = "['ok',_this] call tb_fnc_inputClosed";
+        };
+    };
+};


### PR DESCRIPTION
## Summary
- set up TextBoard functions in `XEH_preInit.sqf`
- add client Draw3D handler function
- create boards server-side and broadcast handler to all clients
- ensure console actions are added for every player

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68429e2f0174832a936576c14bfde8e7